### PR TITLE
Updated to Art-Net 4 Revision DI

### DIFF
--- a/ArtNet/Packets/ArtAddress.cs
+++ b/ArtNet/Packets/ArtAddress.cs
@@ -42,14 +42,14 @@ namespace ArtNet.Packets
         /// </summary>
         public byte BindIndex;
         /// <summary>
-        /// The array represents a null terminated short name for the Node.
+        /// The array represents a null terminated port name for port of this Node.
         /// The Controller uses the ArtAddress packet to program this string. 
         /// Max length is 17 characters plus the null. 
         /// The Node will ignore this value if the string is null. 
         /// <para>This is a fixed length field, although the string it contains can be shorter than the field.</para>
         /// </summary>
         [String(FixedSize = 18)]
-        public string ShortName;
+        public string PortName;
         /// <summary>
         /// The array represents a null terminated long name for the Node.
         /// The Controller uses the ArtAddress packet to program this string. 
@@ -57,7 +57,7 @@ namespace ArtNet.Packets
         /// The Node will ignore this value if the string is null. 
         /// <para>This is a fixed length field, although the string it contains can be shorter than the field.</para>
         /// </summary>
-        [String(FixedSize = 18)]
+        [String(FixedSize = 64)]
         public string LongName;
         /// <summary>
         /// Bits 3-0 of the 15 bit Port-Address for a given input port are encoded into the bottom 4 bits of this field. 

--- a/ArtNet/Packets/ArtDataReply.cs
+++ b/ArtNet/Packets/ArtDataReply.cs
@@ -88,7 +88,7 @@ namespace ArtNet.Packets
 
         public DataRequestCodes Request
         {
-            get => RequestLo | RequestHi << 8;
+            get => (DataRequestCodes)(RequestLo | RequestHi << 8);
             set
             {
                 RequestHi = (byte)((ushort)value & 0xFF);
@@ -106,12 +106,12 @@ namespace ArtNet.Packets
             }
         }
 
-        public ArtCommand() : base(OpCodes.OpCommand)
+        public ArtDataReply() : base(OpCodes.OpCommand)
         {
 
         }
 
-        public static new ArtCommand FromData(ArtNetData data)
+        public static new ArtDataReply FromData(ArtNetData data)
         {
             var stream = new MemoryStream(data.Buffer);
             var reader = new BinaryObjectReader(stream)
@@ -119,7 +119,7 @@ namespace ArtNet.Packets
                 Position = 10
             };
 
-            ArtCommand packet = reader.ReadObject<ArtCommand>();
+            ArtDataReply packet = reader.ReadObject<ArtDataReply>();
 
             packet.PacketData = data;
 

--- a/ArtNet/Packets/ArtDataReply.cs
+++ b/ArtNet/Packets/ArtDataReply.cs
@@ -8,11 +8,11 @@ using NoisyCowStudios.Bin2Object;
 namespace ArtNet.Packets
 {
     /// <summary>
-    /// The ArtCommand packet is used to send property set style commands.
-    /// The packet can be unicast or broadcast, the decision being application specific.
+    /// The ArtDataReply packet is unicast by a Node in response to an ArtDataRequest packet.
+    /// In all scenarios, the ArtDataReply is unicast to the IP address of the sender.
     /// </summary>
-    [OpCode(OpCode = OpCodes.OpCommand)]
-    public class ArtCommand : ArtNetPacket
+    [OpCode(OpCode = OpCodes.OpDataReply)]
+    public class ArtDataReply : ArtNetPacket
     {
         /// <summary>
         /// High byte of the Art-Net protocol revision number.
@@ -36,27 +36,73 @@ namespace ArtNet.Packets
         /// </summary>
         public byte EstaManLo;
         /// <summary>
-        /// The length of the text array below. High Byte
+        /// The high byte of the Oem code.
         /// </summary>
-        public byte LengthHi;
+        public byte OemHi;
         /// <summary>
-        /// Low Byte.
+        /// The low byte of the Oem code.
+        /// The Oem code uniquely identifies the product sending this packet.
         /// </summary>
-        public byte LengthLo;
+        public byte OemLo;
         /// <summary>
-        /// ASCII text array, null terminated.
-        /// Max length is 512 bytes including the null terminator.
+        /// The reply contents. Hi byte. See DataRequestCodes
         /// </summary>
-        [ArrayLength(FieldName = "Length")]
-        public string Data;
+        public byte RequestHi;
+        /// <summary>
+        /// The reply contents. Lo byte.
+        /// </summary>
+        public byte RequestLo;
+        /// <summary>
+        /// Length of payload. Hi byte.
+        /// </summary>
+        public byte PayLenHi;
+        /// <summary>
+        /// Length of payload. Lo byte.
+        /// </summary>
+        public byte PayLenLo;
+        /// <summary>
+        /// Transmit as zero, receivers don’t test.
+        /// </summary>
+        [ArrayLength(FieldName = "PayLen")]
+        public string PayLoad;
 
-        public int Length
+        public int EstaMan
         {
-            get => LengthLo | LengthHi << 8;
+            get => EstaManLo | EstaManHi << 8;
             set
             {
-                LengthLo = (byte)(value & 0xFF);
-                LengthHi = (byte)(value >> 8);
+                EstaManLo = (byte)(value & 0xFF);
+                EstaManHi = (byte)(value >> 8);
+            }
+        }
+
+        public int Oem
+        {
+            get => OemLo | OemHi << 8;
+            set
+            {
+                OemLo = (byte)(value & 0xFF);
+                OemHi = (byte)(value >> 8);
+            }
+        }
+
+        public DataRequestCodes Request
+        {
+            get => RequestLo | RequestHi << 8;
+            set
+            {
+                RequestHi = (byte)((ushort)value & 0xFF);
+                RequestLo = (byte)((ushort)value >> 8);
+            }
+        }
+
+        public int PayLen
+        {
+            get => PayLenLo | PayLenHi << 8;
+            set
+            {
+                PayLenLo = (byte)(value & 0xFF);
+                PayLenHi = (byte)(value >> 8);
             }
         }
 

--- a/ArtNet/Packets/ArtDataRequest.cs
+++ b/ArtNet/Packets/ArtDataRequest.cs
@@ -8,11 +8,13 @@ using NoisyCowStudios.Bin2Object;
 namespace ArtNet.Packets
 {
     /// <summary>
-    /// The ArtCommand packet is used to send property set style commands.
-    /// The packet can be unicast or broadcast, the decision being application specific.
+    /// The ArtDataRequest packet is used to request data such as product URL
+    /// The ArtDataRequest packet is unicast by a Controller to a Node.
+    /// If the Node supports this feature it will respond by unicasting an ArtDataReply.
+    /// In all scenarios, the ArtDataReply is unicast to the IP address of the sender
     /// </summary>
-    [OpCode(OpCode = OpCodes.OpCommand)]
-    public class ArtCommand : ArtNetPacket
+    [OpCode(OpCode = OpCodes.OpDataRequest)]
+    public class ArtDataRequest : ArtNetPacket
     {
         /// <summary>
         /// High byte of the Art-Net protocol revision number.
@@ -36,27 +38,55 @@ namespace ArtNet.Packets
         /// </summary>
         public byte EstaManLo;
         /// <summary>
-        /// The length of the text array below. High Byte
+        /// The high byte of the Oem code.
         /// </summary>
-        public byte LengthHi;
+        public byte OemHi;
         /// <summary>
-        /// Low Byte.
+        /// The low byte of the Oem code.
+        /// The Oem code uniquely identifies the product sending this packet.
         /// </summary>
-        public byte LengthLo;
+        public byte OemLo;
         /// <summary>
-        /// ASCII text array, null terminated.
-        /// Max length is 512 bytes including the null terminator.
+        /// The data being requested. Hi byte. See DataRequestCodes
         /// </summary>
-        [ArrayLength(FieldName = "Length")]
-        public string Data;
+        public byte RequestHi;
+        /// <summary>
+        /// The data being requested. Lo byte.
+        /// </summary>
+        public byte RequestLo;
+        /// <summary>
+        /// Transmit as zero, receivers don’t test.
+        /// </summary>
+        [ArrayLength(FixedSize = 22)]
+        public string Spare;
 
-        public int Length
+        public int EstaMan
         {
-            get => LengthLo | LengthHi << 8;
+            get => EstaManLo | EstaManHi << 8;
             set
             {
-                LengthLo = (byte)(value & 0xFF);
-                LengthHi = (byte)(value >> 8);
+                EstaManLo = (byte)(value & 0xFF);
+                EstaManHi = (byte)(value >> 8);
+            }
+        }
+
+        public int Oem
+        {
+            get => OemLo | OemHi << 8;
+            set
+            {
+                OemLo = (byte)(value & 0xFF);
+                OemHi = (byte)(value >> 8);
+            }
+        }
+
+        public DataRequestCodes Request
+        {
+            get => RequestLo | RequestHi << 8;
+            set
+            {
+                RequestHi = (byte)((ushort)value & 0xFF);
+                RequestLo = (byte)((ushort)value >> 8);
             }
         }
 

--- a/ArtNet/Packets/ArtDataRequest.cs
+++ b/ArtNet/Packets/ArtDataRequest.cs
@@ -82,7 +82,7 @@ namespace ArtNet.Packets
 
         public DataRequestCodes Request
         {
-            get => RequestLo | RequestHi << 8;
+            get => (DataRequestCodes)(RequestLo | RequestHi << 8);
             set
             {
                 RequestHi = (byte)((ushort)value & 0xFF);
@@ -90,12 +90,12 @@ namespace ArtNet.Packets
             }
         }
 
-        public ArtCommand() : base(OpCodes.OpCommand)
+        public ArtDataRequest() : base(OpCodes.OpCommand)
         {
 
         }
 
-        public static new ArtCommand FromData(ArtNetData data)
+        public static new ArtDataRequest FromData(ArtNetData data)
         {
             var stream = new MemoryStream(data.Buffer);
             var reader = new BinaryObjectReader(stream)
@@ -103,7 +103,7 @@ namespace ArtNet.Packets
                 Position = 10
             };
 
-            ArtCommand packet = reader.ReadObject<ArtCommand>();
+            ArtDataRequest packet = reader.ReadObject<ArtDataRequest>();
 
             packet.PacketData = data;
 

--- a/ArtNet/Packets/ArtDiagData.cs
+++ b/ArtNet/Packets/ArtDiagData.cs
@@ -38,10 +38,15 @@ namespace ArtNet.Packets
         /// </remarks>
         public PriorityCodes Priority;
         /// <summary>
+        /// The logical DMX port of the product to which the message relates.
+        /// Set to zero for general messages.
+        /// This field if purely informational and is designed to allow development tools to filter diagnostics.
+        /// </summary>
+        public byte LogicalPort;
+        /// <summary>
         /// Ignore by receiver, set to zero by sender
         /// </summary>
-        [ArrayLength(FixedSize = 2)]
-        public byte[] Filler2;
+        public byte Filler3;
         /// <summary>
         /// The length of the text array below. High Byte
         /// </summary>
@@ -51,9 +56,10 @@ namespace ArtNet.Packets
         /// </summary>
         public byte LengthLo;
         /// <summary>
-        /// ASCII text array, null terminated. Max length is 512 bytes including the null terminator.
+        /// ASCII text array, null terminated.
+        /// Max length is 512 bytes including the null terminator.
         /// </summary>
-        [String(FixedSize = 512)]
+        [ArrayLength(FieldName = "Length")]
         public string Data;
 
         public int Length

--- a/ArtNet/Packets/ArtIpProg.cs
+++ b/ArtNet/Packets/ArtIpProg.cs
@@ -7,6 +7,26 @@ using NoisyCowStudios.Bin2Object;
 
 namespace ArtNet.Packets
 {
+    public struct IpProgCommand
+    {
+        /// <summary> 
+        /// Set to enable any programming
+        /// </summary>
+        public bool EnableAnyProgramming;
+        /// <summary> 
+        /// Set to enable DHCP (if set ignore lower bits).
+        /// </summary>
+        public bool EnableDHCP;
+        public bool ProgramDefaultGatway;
+        /// <summary> 
+        /// Set to return all three parameters to default
+        /// </summary>
+        public bool ReturnToDefault;
+        public bool ProgramIpAddress;
+        public bool ProgramSubnetMask
+        public bool ProgramPort;
+    }
+
     [OpCode(OpCode = OpCodes.OpIpProg)]
     public class ArtIpProg : ArtNetPacket
     {
@@ -28,14 +48,16 @@ namespace ArtNet.Packets
         /// <summary>
         /// Defines the how this packet is processed. If all bits are clear, this is an enquiry only.
         /// </summary>
-        /// <remarks>
-        /// Refer to the ArtNet <see href="https://artisticlicence.com/WebSiteMaster/User%20Guides/art-net.pdf#page=38">User Guide</see> on how to use.
-        /// </remarks>
+        [SkipBin2Object]
+        public IpProgCommand IpProgCommand;
+        /// <summary>
+        /// Holds the flags stored in IpProgCommand
+        /// </summary>
         public byte Command;
         /// <summary>
         /// Set to zero. Pads data structure for word alignment
         /// </summary>
-        public byte Filler1;
+        public byte Filler4;
         /// <summary>
         /// IP Address to be programmed into Node if enabled by Command Field
         /// </summary>
@@ -49,9 +71,14 @@ namespace ArtNet.Packets
         [Obsolete("(Deprecated)")]
         public byte[] ProgPort;
         /// <summary>
+        /// Default Gateway to be programmed into Node if enabled by Command Field
+        /// </summary>
+        [ArrayLength(FixedSize = 4)]
+        public byte[] ProgDg;
+        /// <summary>
         /// Transmit as zero, receivers don’t test.
         /// </summary>
-        [ArrayLength(FixedSize = 8)]
+        [ArrayLength(FixedSize = 4)]
         public byte[] Spare;
 
         public ArtIpProg() : base(OpCodes.OpIpProg)
@@ -67,7 +94,17 @@ namespace ArtNet.Packets
                 Position = 10
             };
 
-            ArtIpProg packet = reader.ReadObject<ArtIpProg>();
+            ArtIpProg packet = reader.ReadObject<ArtIpProg>()
+            packet.IpProgCommand = new IpProgCommand
+            {
+                EnableAnyProgramming = (packet.Command & (1 << 7)) > 0,
+                EnableDHCP = (packet.Command & (1 << 6)) > 0,
+                ProgramDefaultGatway = (packet.Command & (1 << 4)) > 0,
+                ReturnToDefault = (packet.Command & (1 << 3)) > 0,
+                ProgramIpAddress = (packet.Command & (1 << 2)) > 0,
+                ProgramSubnetMask = (packet.Command & (1 << 1)) > 0,
+                ProgramPort = (packet.Command & (1 << 0)) > 0,
+            };
 
             packet.PacketData = data;
 
@@ -76,6 +113,36 @@ namespace ArtNet.Packets
 
         public override byte[] ToArray()
         {
+            Command = 0;
+            if (IpProgCommand.EnableAnyProgramming)
+            {
+                Command |= (1 << 7);
+            }
+            if (IpProgCommand.EnableDHCP)
+            {
+                Command |= (1 << 6);
+            }
+            if (IpProgCommand.ProgramDefaultGatway)
+            {
+                Command |= (1 << 4);
+            }
+            if (IpProgCommand.ReturnToDefault)
+            {
+                Command |= (1 << 3);
+            }
+            if (IpProgCommand.ProgramIpAddress)
+            {
+                Command |= (1 << 2);
+            }
+            if (IpProgCommand.ProgramSubnetMask)
+            {
+                Command |= (1 << 1);
+            }
+            if (IpProgCommand.ProgramPort)
+            {
+                Command |= (1 << 0);
+            }
+
             var stream = new MemoryStream();
             var writer = new BinaryObjectWriter(stream);
             writer.Write(ID);

--- a/ArtNet/Packets/ArtIpProg.cs
+++ b/ArtNet/Packets/ArtIpProg.cs
@@ -17,13 +17,25 @@ namespace ArtNet.Packets
         /// Set to enable DHCP (if set ignore lower bits).
         /// </summary>
         public bool EnableDHCP;
+        /// <summary> 
+        /// Set to program the default gateway address
+        /// </summary>
         public bool ProgramDefaultGatway;
         /// <summary> 
         /// Set to return all three parameters to default
         /// </summary>
         public bool ReturnToDefault;
+        /// <summary> 
+        /// Set to program the IP address
+        /// </summary>
         public bool ProgramIpAddress;
-        public bool ProgramSubnetMask
+        /// <summary> 
+        /// Set to program the subnet mask
+        /// </summary>
+        public bool ProgramSubnetMask;
+        /// <summary> 
+        /// Set to program the artnet port (Deprecated)
+        /// </summary>
         public bool ProgramPort;
     }
 
@@ -68,7 +80,11 @@ namespace ArtNet.Packets
         /// </summary>
         [ArrayLength(FixedSize = 4)]
         public byte[] ProgSm;
+        /// <summary>
+        /// Artnet port to be programmed into Node if enabled by Command Field (Deprecated)
+        /// </summary>
         [Obsolete("(Deprecated)")]
+        [ArrayLength(FixedSize = 2)]
         public byte[] ProgPort;
         /// <summary>
         /// Default Gateway to be programmed into Node if enabled by Command Field
@@ -94,7 +110,7 @@ namespace ArtNet.Packets
                 Position = 10
             };
 
-            ArtIpProg packet = reader.ReadObject<ArtIpProg>()
+            ArtIpProg packet = reader.ReadObject<ArtIpProg>();
             packet.IpProgCommand = new IpProgCommand
             {
                 EnableAnyProgramming = (packet.Command & (1 << 7)) > 0,

--- a/ArtNet/Packets/ArtIpProgReply.cs
+++ b/ArtNet/Packets/ArtIpProgReply.cs
@@ -45,8 +45,17 @@ namespace ArtNet.Packets
         /// <summary>
         /// Transmit as zero, receivers don’t test.
         /// </summary>
-        [ArrayLength(FixedSize = 7)]
-        public byte[] Spare;
+        public byte Spare2;
+        /// <summary>
+        /// Default Gateway of Node.
+        /// </summary>
+        [ArrayLength(FixedSize = 4)]
+        public byte[] ProgDg;
+        /// <summary>
+        /// Transmit as zero, receivers don’t test.
+        /// </summary>
+        [ArrayLength(FixedSize = 2)]
+        public byte[] Spare78;
 
         public ArtIpProgReply() : base(OpCodes.OpIpProgReply)
         {

--- a/ArtNet/Packets/ArtPoll.cs
+++ b/ArtNet/Packets/ArtPoll.cs
@@ -4,6 +4,7 @@ using static ArtNet.Attributes;
 using ArtNet.IO;
 using ArtNet.Packets.Codes;
 using NoisyCowStudios.Bin2Object;
+using System.Buffers.Binary;
 
 namespace ArtNet.Packets
 {
@@ -105,10 +106,10 @@ namespace ArtNet.Packets
             };
             // Read optional bytes
             // ReadUint16 reads in little endian, convert to big
-            if ((stream.length - reader.Position) >= 2) AddressTop = BinaryPrimitives.ReverseEndianness(reader.ReadUInt16());
-            if ((stream.length - reader.Position) >= 2) AddressBottom = BinaryPrimitives.ReverseEndianness(reader.ReadUInt16());
-            if ((stream.length - reader.Position) >= 2) EstaMan = BinaryPrimitives.ReverseEndianness(reader.ReadUInt16());
-            if ((stream.length - reader.Position) >= 2) Oem = BinaryPrimitives.ReverseEndianness(reader.ReadUInt16());
+            if ((stream.Length - reader.Position) >= 2) packet.AddressTop = BinaryPrimitives.ReverseEndianness(reader.ReadUInt16());
+            if ((stream.Length - reader.Position) >= 2) packet.AddressBottom = BinaryPrimitives.ReverseEndianness(reader.ReadUInt16());
+            if ((stream.Length - reader.Position) >= 2) packet.EstaMan = BinaryPrimitives.ReverseEndianness(reader.ReadUInt16());
+            if ((stream.Length - reader.Position) >= 2) packet.Oem = BinaryPrimitives.ReverseEndianness(reader.ReadUInt16());
             packet.PacketData = data;
             return packet;
         }

--- a/ArtNet/Packets/ArtPoll.cs
+++ b/ArtNet/Packets/ArtPoll.cs
@@ -49,6 +49,28 @@ namespace ArtNet.Packets
         /// The lowest priority of diagnostics message that should be sent. See <see cref="PriorityCodes"/>.
         /// </summary>
         public PriorityCodes Priority;
+        /// <summary>
+        /// Top of the range of Port-Addresses to be tested if Targeted Mode is active.
+        /// </summary>
+        /// <remark>This is optional, consider zero if packet is too short</remarK>
+        [SkipBin2Object]
+        public int AddressTop;
+        /// <summary>
+        /// Bottom of the range of Port-Addresses to be tested if Targeted Mode is active.
+        /// </summary>
+        /// <remark>This is optional, consider zero if packet is too short</remarK>
+        [SkipBin2Object]
+        public int AddressBottom;
+        /// <summary>
+        /// The ESTA Manufacturer Code is assigned by ESTA and uniquely identifies the manufacturer that generated this packet.
+        /// </summary>
+        [SkipBin2Object]
+        public int EstaMan;
+        /// <summary>
+        /// The Oem code uniquely identifies the product sending this packet.
+        /// </summary>
+        [SkipBin2Object]
+        public int Oem;
 
         public int ProtVer
         {
@@ -81,6 +103,12 @@ namespace ArtNet.Packets
                 SendDiagnostics = (packet.Flags & (1 << 2)) > 0,
                 ReplyOnChange = (packet.Flags & (1 << 1)) > 0,
             };
+            // Read optional bytes
+            // ReadUint16 reads in little endian, convert to big
+            if ((stream.length - reader.Position) >= 2) AddressTop = BinaryPrimitives.ReverseEndianness(reader.ReadUInt16());
+            if ((stream.length - reader.Position) >= 2) AddressBottom = BinaryPrimitives.ReverseEndianness(reader.ReadUInt16());
+            if ((stream.length - reader.Position) >= 2) EstaMan = BinaryPrimitives.ReverseEndianness(reader.ReadUInt16());
+            if ((stream.length - reader.Position) >= 2) Oem = BinaryPrimitives.ReverseEndianness(reader.ReadUInt16());
             packet.PacketData = data;
             return packet;
         }
@@ -112,6 +140,16 @@ namespace ArtNet.Packets
             writer.Write((short)OpCode);
 
             writer.WriteObject(this);
+            // Write optional extra bytes
+            writer.Write((byte)((AddressTop >> 8) & 0xff));
+            writer.Write((byte)(AddressTop & 0xff));
+            writer.Write((byte)((AddressBottom >> 8) & 0xff));
+            writer.Write((byte)(AddressBottom & 0xff));
+            writer.Write((byte)((EstaMan >> 8) & 0xff));
+            writer.Write((byte)(EstaMan & 0xff));
+            writer.Write((byte)((Oem >> 8) & 0xff));
+            writer.Write((byte)(Oem & 0xff));
+
             return stream.ToArray();
         }
 

--- a/ArtNet/Packets/ArtPollReply.cs
+++ b/ArtNet/Packets/ArtPollReply.cs
@@ -321,7 +321,7 @@ namespace ArtNet.Packets
                 $"IP: {IP}\n" +
                 $"Port: {Port}\n" +
                 $"Mac: {sb}\n" +
-                $"ShortName: {ShortName}\n" +
+                $"PortName: {PortName}\n" +
                 $"LongName: {LongName}\n" +
                 $"NodeReport {NodeReport}\n" +
                 $"StyleCode: {Enum.GetName(Style)}\n" +

--- a/ArtNet/Packets/ArtPollReply.cs
+++ b/ArtNet/Packets/ArtPollReply.cs
@@ -78,13 +78,13 @@ namespace ArtNet.Packets
         /// </summary>
         public byte EstaManHi;
         /// <summary>
-        /// The array represents a null terminated short name for the Node.
+        /// The array represents a null terminated name for each port of the Node.
         /// The Controller uses the ArtAddress packet to program this string.
         /// Max length is 17 characters plus the null. 
         /// This is a fixed length field, although the string it contains can be shorter than the field.
         /// </summary>
         [String(FixedSize = 18)]
-        public string ShortName;
+        public string PortName;
         /// <summary>
         /// The array represents a null terminated long name for the Node.
         /// The Controller uses the ArtAddress packet to program this string. 
@@ -201,16 +201,40 @@ namespace ArtNet.Packets
         /// This array defines output status of the node
         /// </summary>
         [ArrayLength(FixedSize = 4)]
-        public byte[] GoodOutput2;
+        public byte[] GoodOutputB;
         /// <summary>
         /// General Status register containing bit fields.
         /// </summary>
         public byte Status3;
         /// <summary>
-        /// Transmit as zero. For future expansion.
-        /// Size: 21 * byte(8)
+        /// RDMnet and LLRP Default Responder UID
         /// </summary>
-        [ArrayLength(FixedSize = 168)]
+        [ArrayLength(FixedSize = 6)]
+        public byte[] DefaulRespUID;
+        /// <summary>
+        /// Available for user specific data
+        /// </summary>
+        public byte UserHi;
+        /// <summary>
+        /// Available for user specific data
+        /// </summary>
+        public byte UserLo;
+        /// <summary>
+        /// Hi byte of RefreshRate
+        /// </summary>
+        public byte RefreshRateHi;
+        /// <summary>
+        /// Lo Byte of RefreshRate.
+        /// RefreshRate allows the device to specify the maximum refresh rate, expressed in Hz, at which it can process ArtDmx. 
+        /// This is designed to allow refresh rates above DMX512 rates, for gateways that implement other protocols such as SPI.
+        /// A value of 0 to 44 represents the maximum DMX512 rate of 44Hz
+        /// </summary>
+        public byte RefreshRateLo;
+        /// <summary>
+        /// Transmit as zero. For future expansion.
+        /// Size: 11 bytes?
+        /// </summary>
+        [ArrayLength(FixedSize = 11)]
         public byte[] Filler;
 
         public int Oem
@@ -220,6 +244,26 @@ namespace ArtNet.Packets
             {
                 OemLo = (byte)(value & 0xFF);
                 OemHi = (byte)(value >> 8);
+            }
+        }
+
+        public int User
+        {
+            get => UserLo | UserHi << 8;
+            set
+            {
+                UserLo = (byte)(value & 0xFF);
+                UserHi = (byte)(value >> 8);
+            }
+        }
+
+        public int RefreshRate
+        {
+            get => RefreshRateLo | RefreshRateHi << 8;
+            set
+            {
+                RefreshRateLo = (byte)(value & 0xFF);
+                RefreshRateHi = (byte)(value >> 8);
             }
         }
 

--- a/ArtNet/Packets/ArtRdm.cs
+++ b/ArtNet/Packets/ArtRdm.cs
@@ -37,13 +37,15 @@ namespace ArtNet.Packets
         [ArrayLength(FixedSize = 7)]
         public byte[] Spare;
         /// <summary>
+        /// The top 7 bits of 15 bit Port-Address that should action this command.
+        /// </summary>
+        public byte Net;
+        /// <summary>
         /// Defines the packet action.
         /// </summary>
         public RdmCodes Command;
         /// <summary>
-        /// The low 8 bits of the Port-Address of the Output Gateway DMX Port that generated this packet.
-        /// The high nibble is the Sub-Net switch. 
-        /// The low nibble corresponds to the Universe.
+        /// The low 8 bits of the Port-Address that should action this command.
         /// </summary>
         public byte Address;
         /// <summary>

--- a/ArtNet/Packets/ArtTodControl.cs
+++ b/ArtNet/Packets/ArtTodControl.cs
@@ -34,13 +34,15 @@ namespace ArtNet.Packets
         [ArrayLength(FixedSize = 7)]
         public byte[] Spare;
         /// <summary>
+        /// The top 7 bits of the Port-Address of the Output Gateway DMX Port that should action this command.
+        /// </summary>
+        public byte Net;
+        /// <summary>
         /// Defines the packet contents.
         /// </summary>
         public TodControlCodes Command;
         /// <summary>
-        /// The low 8 bits of the Port-Address of the Output Gateway DMX Port that generated this packet.
-        /// The high nibble is the Sub-Net switch. 
-        /// The low nibble corresponds to the Universe.
+        /// The low byte of the 15 bit Port-Address of the DMX Port that should action this command.
         /// </summary>
         public byte Address;
 

--- a/ArtNet/Packets/ArtTodData.cs
+++ b/ArtNet/Packets/ArtTodData.cs
@@ -56,7 +56,7 @@ namespace ArtNet.Packets
         /// <value>
         /// Either TodFull(0x00) or TodNak(0xFF, not available)
         /// </value>
-        public byte CommandResponse;
+        public TodDataCodes CommandResponse;
         /// <summary>
         /// The low 8 bits of the Port-Address of the Output Gateway DMX Port that generated this packet.
         /// The high nibble is the Sub-Net switch. 

--- a/ArtNet/Packets/ArtTodData.cs
+++ b/ArtNet/Packets/ArtTodData.cs
@@ -4,6 +4,7 @@ using ArtNet.IO;
 using ArtNet.Packets.Codes;
 using ArtNet.Rdm;
 using NoisyCowStudios.Bin2Object;
+using Art.Net.Packets.Codes;
 
 namespace ArtNet.Packets
 {

--- a/ArtNet/Packets/Codes/AddressCommands.cs
+++ b/ArtNet/Packets/Codes/AddressCommands.cs
@@ -34,6 +34,14 @@
         /// If an output short is being flagged, forces the test to re-run.
         /// </summary>
         AcResetRxFlags = 0x05,
+        /// <summary>
+        /// Enable analysis and debugging mode.
+        /// </summary>
+        AcAnalysisOn = 0x06,
+        /// <summary>
+        /// Disable analysis and debugging mode
+        /// </summary>
+        AcAnalysisOff = 0x07,
 
         // Fail-over configuration commands: These settings should be retained by the node during power cycling
 
@@ -75,6 +83,38 @@
         /// Set DMX Port 3 to Merge in LTP mode.
         /// </summary>
         AcMergeLtp3 = 0x13,
+        /// <summary>
+        /// Set Port 0 direction to output.
+        /// </summary>
+        AcDirectionTx0 = 0x20,
+        /// <summary>
+        /// Set Port 1 direction to output.
+        /// </summary>
+        AcDirectionTx1 = 0x21,
+        /// <summary>
+        /// Set Port 2 direction to output.
+        /// </summary>
+        AcDirectionTx2 = 0x22,
+        /// <summary>
+        /// Set Port 3 direction to output.
+        /// </summary>
+        AcDirectionTx3 = 0x23,
+        /// <summary>
+        /// Set Port 0 direction to input.
+        /// </summary>
+        AcDirectionRx0 = 0x30,
+        /// <summary>
+        /// Set Port 1 direction to input.
+        /// </summary>
+        AcDirectionRx1 = 0x30,
+        /// <summary>
+        /// Set Port 2 direction to input.
+        /// </summary>
+        AcDirectionRx2 = 0x33,
+        /// <summary>
+        /// Set Port 3 direction to input.
+        /// </summary>
+        AcDirectionRx3 = 0x33,
         /// <summary>
         /// Set DMX Port 0 to Merge in HTP (default) mode.
         /// </summary>

--- a/ArtNet/Packets/Codes/DataRequestCodes.cs
+++ b/ArtNet/Packets/Codes/DataRequestCodes.cs
@@ -1,0 +1,39 @@
+﻿namespace ArtNet.Packets.Codes
+{
+    /// <summary>
+    /// The following enum contains the DataRequest Codes.
+    /// <para>These codes are used by ArtDataRequest and ArtDataReply.</para>
+    /// </summary>
+    public enum DataRequestCodes : ushort
+    {
+        /// <summary>
+        /// Controller is polling to establish whether ArtDataRequest is supported.
+        /// </summary>
+        DrPoll = 0x0000,
+        /// <summary>
+        /// URL to manufacturer product page.
+        /// </summary>
+        DrUrlProduct = 0x0001,
+        /// <summary>
+        /// URL to manufacturer user guide.
+        /// </summary>
+        DrUrlUserGuide = 0x0002,
+        /// <summary>
+        /// URL to manufacturer support page.
+        /// </summary>
+        DrUrlSupport = 0x0003,
+        /// <summary>
+        /// URL to manufacturer UDR personality.
+        /// </summary>
+        DrUrlPersUdr = 0x0004,
+        /// <summary>
+        /// URL to manufacturer GDTF personality.
+        /// </summary>
+        DrUrlPersGdtf = 0x0005,
+        /// <summary>
+        /// Manufacturer specific use.
+        /// </summary>
+        /// <remark>Can be 0x8000-0xffff</remark>
+        DrManSpec = 0x8000
+    }
+}

--- a/ArtNet/Packets/Codes/OpCodes.cs
+++ b/ArtNet/Packets/Codes/OpCodes.cs
@@ -33,6 +33,14 @@ namespace ArtNet.Packets.Codes
         /// </summary>
         OpCommand = 0x2400,
         /// <summary>
+        /// Used to request data such as products URLs
+        /// </summary>
+        OpDataRequest = 0x2700,
+        /// <summary>
+        /// Used to reply to ArtDataRequest packets
+        /// </summary>
+        OpDataReply = 0x2800,
+        /// <summary>
         /// This is an ArtDmx data packet. 
         /// It contains zero start code DMX512 information for a single Universe.
         /// </summary>

--- a/ExampleNode/Program.cs
+++ b/ExampleNode/Program.cs
@@ -48,7 +48,7 @@ namespace Example
                         GoodInput = new byte[] { 0x08, 0x08, 0x08, 0x08 },
                         GoodOutput = new byte[] { 0x80, 0x80, 0x80, 0x80 },
                         PortTypes = new byte[] { 0xc0, 0xc0, 0xc0, 0xc0 },
-                        ShortName = "Art.Net\0",
+                        PortName = "Art.Net\0",
                         LongName = "A c# Art-Net 4 Library\0",
                         VersInfoH = 6,
                         VersInfoL = 9,
@@ -60,7 +60,7 @@ namespace Example
                         BindIp = localIP.GetAddressBytes(),
                         SwIn = new byte[] { 0x01, 0x02, 0x03, 0x04 },
                         SwOut = new byte[] { 0x01, 0x02, 0x03, 0x04 },
-                        GoodOutput2 = new byte[] { 0x80, 0x80, 0x80, 0x80 },
+                        GoodOutputB = new byte[] { 0x80, 0x80, 0x80, 0x80 },
 
                         NodeReport = "Up and running\0",
                         Filler = new byte[168]

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -27,7 +27,7 @@ namespace Tests
                 GoodInput = new byte[] { 0x08, 0x08, 0x08, 0x08 },
                 GoodOutput = new byte[] { 0x80, 0x80, 0x80, 0x80 },
                 PortTypes = new byte[] { 0xc0, 0xc0, 0xc0, 0xc0 },
-                ShortName = "ShortName Test",
+                PortName = "PortName Test",
                 LongName = "Art.Net LongName Test",
                 EstaManLo = 0,
                 VersInfoH = 6,
@@ -46,7 +46,7 @@ namespace Tests
                 BindIp = IPAddress.Parse("127.0.0.1").GetAddressBytes(),
                 SwIn = new byte[] { 0x01, 0x02, 0x03, 0x04 },
                 SwOut = new byte[] { 0x01, 0x02, 0x03, 0x04 },
-                GoodOutput2 = new byte[] { 0x80, 0x80, 0x80, 0x80 },
+                GoodOutputB = new byte[] { 0x80, 0x80, 0x80, 0x80 },
 
                 NodeReport = "NodeReport Test",
                 Filler = new byte[168]
@@ -57,7 +57,7 @@ namespace Tests
             Assert.AreEqual(altPacket.OpCode, pollReply.OpCode);
 
             var pollReplyPacket = altPacket.Cast<ArtPollReply>();
-            Assert.AreEqual(pollReplyPacket.ShortName, pollReply.ShortName);
+            Assert.AreEqual(pollReplyPacket.PortName, pollReply.PortName);
             Assert.AreEqual(pollReplyPacket.LongName, pollReply.LongName);
 
             Assert.AreEqual(pollReplyPacket.NodeReport, pollReply.NodeReport);


### PR DESCRIPTION
# Changes

## Packets

ArtAddress:
- ShortName Renamed to PortName
- Fixed length of LongName (18->64)

ArtCommand:
- Make length of Data come from the Length field

ArtDiagData:
- Replace Filler2 with LogicalPort and Filler3
- Make length of Data come from the Length field

ArtIpProg:
- Added ProgDg (Default Gateway)
- Make struct to hold Command flags

ArtIpProgReply:
- Added ProgDg (Default Gateway)

ArtPoll:
- Added optional extra packet bytes (we need to still be able to handle 14 byte packets)

ArtPollReply:
- Renamed ShortName to PortName
- Renamed GoodOutput2 to GoodOutputB
- Added DefaulRespUID
- Added UserHi + UserLo
- Added RefreshRateHi + RefreshRateLo
- Adjusted size of Filler

ArtRdm:
- Added Net

ArtTodControl:
- Added Net

ArtTodData:
- Change type of CommandResponse to TodDataCodes

### Added

Support for the following packets has been added:
- ArtDataRequest
- ArtDataReply

## Codes

AddressCommands:
- Added AcAnalysisOn
- Added AcAnalysisOff
- Added AcDirectionTx0-3
- Added AcDirectionRx0-3

OpCodes:
- Added OpDataRequest
- Added OpDataReply